### PR TITLE
Fix Bug where specifying CORS origin allows all origins

### DIFF
--- a/muxy/settings.py
+++ b/muxy/settings.py
@@ -182,4 +182,4 @@ CORS_ALLOWED_ORIGINS = [
     o for o in os.getenv("CORS_ALLOWED_ORIGINS", "").split(",") if o
 ]
 # If there is no specific origin to allow, accept all origins
-CORS_ALLOW_ALL_ORIGINS = len(CORS_ALLOWED_ORIGINS) > 0
+CORS_ALLOW_ALL_ORIGINS = len(CORS_ALLOWED_ORIGINS) == 0


### PR DESCRIPTION
Logic on this line was reversed, if the user specified a CORS origin, `CORS_ALLOW_ALL_ORIGINS` would be true, actually allowing all origins rather than just the specified origin(s), however if no origins were set, no origins would be allowed.