### PR TITLE
Revert postgres migration back to sqlite3

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -11,23 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     container: python:3.7
 
-    # Service containers to run with `container-job`
-    services:
-      # Label used to access the service container
-      postgres:
-        # Docker Hub image
-        image: postgres
-        # Provide the password for postgres
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
       - uses: actions/checkout@v2
       - name: Install Dependencies
@@ -37,8 +20,3 @@ jobs:
       - name: Run Tests
         run: |
           python manage.py test
-        env:
-          PGHOST: postgres
-          PGPORT: 5432
-          PGUSER: postgres
-          PGPASSWORD: postgres

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Copy `env.sample` to `.env` and update if necessary. You should set at least:
 - `CORS_ALLOWED_ORIGINS`: Add your request origin.
 - `LANGUAGE_CODE`: Set default language code.
 - `TIME_ZONE`: Set server time zone if different than UTC.
-- `PG*`: Set to corresponding Postgres database server
+- `DB_PATH`: Set path where to save database file
 
 Now, run migrations to create and prepare database:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,38 +1,18 @@
 version: "3.7"
 
 services:
-  db:
-    image: postgres
-    env_file:
-      - .env
-    environment:
-      - POSTGRES_DB=muxy
-      - POSTGRES_USER=muxy
-      - POSTGRES_PASSWORD=muxy
-    ports:
-      - 5432:5432
-    volumes:
-      - pgdata:/var/lib/postgresql/data
-
   muxy:
     build: .
     command: gunicorn muxy.wsgi:application --workers 3 --bind 0.0.0.0:8000
     image: muxy:latest
     env_file:
       - .env
-    environment:
-      - PGHOST=db
-      - PGDATABASE=muxy
-      - PGUSER=muxy
-      - PGPASSWORD=muxy
     volumes:
       - .:/usr/src/app
     stdin_open: true
     tty: true
     ports:
       - 8000:8000
-    depends_on:
-      - db
 
   nginx-rtmp:
     build: ./docker/nginx-rtmp/
@@ -41,6 +21,3 @@ services:
       - 8080:8080
     depends_on:
       - muxy
-
-volumes:
-  pgdata:

--- a/env.sample
+++ b/env.sample
@@ -6,13 +6,7 @@ CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8080
 LANGUAGE_CODE=en-us
 TIME_ZONE=UTC
 
-PGDATABASE=muxy
-PGUSER=muxy
-PGPASSWORD=insert_password
-PGHOST=localhost
-PGPORT=5432
-
-DB_PATH=~/muxy.sqlite3
+DB_PATH=./muxy.db
 
 NGINX_RTMP_UPDATE_TIMEOUT=30
 

--- a/muxy/settings.py
+++ b/muxy/settings.py
@@ -86,12 +86,9 @@ WSGI_APPLICATION = "muxy.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.postgresql_psycopg2",
-        "NAME": os.getenv("PGDATABASE"),
-        "USER": os.getenv("PGUSER"),
-        "PASSWORD": os.getenv("PGPASSWORD"),
-        "HOST": os.getenv("PGHOST"),
-        "PORT": os.getenv("PGPORT"),
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": os.getenv("DB_PATH", BASE_DIR / "db.sqlite3"),
+        "OPTIONS": {"timeout": 20},
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ djangorestframework-api-key==2.0.0
 djangorestframework==3.12.2
 drf-spectacular==0.21.0
 gunicorn==20.0.4
-psycopg2-binary==2.9.9
 python-dotenv==0.15.0


### PR DESCRIPTION
In retrospect, I think it was a good idea to use SQLite because it is simpler to setup, manage, consumes less resources and it's good enoguh for the requirements of this application.